### PR TITLE
Change the cache partition size check into warnings.

### DIFF
--- a/tools/releasetools/blockimgdiff.py
+++ b/tools/releasetools/blockimgdiff.py
@@ -483,7 +483,7 @@ class BlockImageDiff(object):
       if free_string:
         out.append("".join(free_string))
 
-      if self.version >= 2:
+      if self.version >= 2 and common.OPTIONS.cache_size is not None:
         # Sanity check: abort if we're going to need more stash space than
         # the allowed size (cache_size * threshold). There are two purposes
         # of having a threshold here. a) Part of the cache may have been
@@ -524,10 +524,16 @@ class BlockImageDiff(object):
 
     if self.version >= 2:
       max_stashed_size = max_stashed_blocks * self.tgt.blocksize
-      max_allowed = common.OPTIONS.cache_size * common.OPTIONS.stash_threshold
-      print("max stashed blocks: %d  (%d bytes), limit: %d bytes (%.2f%%)\n" % (
-          max_stashed_blocks, max_stashed_size, max_allowed,
-          max_stashed_size * 100.0 / max_allowed))
+      OPTIONS = common.OPTIONS
+      if OPTIONS.cache_size is not None:
+        max_allowed = OPTIONS.cache_size * OPTIONS.stash_threshold
+        print("max stashed blocks: %d  (%d bytes), "
+              "limit: %d bytes (%.2f%%)\n" % (
+              max_stashed_blocks, max_stashed_size, max_allowed,
+              max_stashed_size * 100.0 / max_allowed))
+      else:
+        print("max stashed blocks: %d  (%d bytes), limit: <unknown>\n" % (
+              max_stashed_blocks, max_stashed_size))
 
   def ReviseStashSize(self):
     print("Revising stash size...")

--- a/tools/releasetools/common.py
+++ b/tools/releasetools/common.py
@@ -68,6 +68,10 @@ OPTIONS = Options()
 # Values for "certificate" in apkcerts that mean special things.
 SPECIAL_CERT_STRINGS = ("PRESIGNED", "EXTERNAL")
 
+# Stash size cannot exceed cache_size * threshold.
+OPTIONS.cache_size = None
+OPTIONS.stash_threshold = 0.8
+
 
 class ExternalError(RuntimeError):
   pass

--- a/tools/releasetools/ota_from_target_files.py
+++ b/tools/releasetools/ota_from_target_files.py
@@ -143,9 +143,6 @@ OPTIONS.oem_source = None
 OPTIONS.fallback_to_full = True
 OPTIONS.full_radio = False
 OPTIONS.full_bootloader = False
-# Stash size cannot exceed cache_size * threshold.
-OPTIONS.cache_size = None
-OPTIONS.stash_threshold = 0.8
 OPTIONS.backuptool = False
 OPTIONS.override_device = 'auto'
 OPTIONS.override_prop = False
@@ -1716,7 +1713,7 @@ def main(argv):
 
     cache_size = OPTIONS.info_dict.get("cache_size", None)
     if cache_size is None:
-      raise RuntimeError("can't determine the cache partition size")
+      print "--- can't determine the cache partition size ---"
     OPTIONS.cache_size = cache_size
 
     if OPTIONS.incremental_source is None:


### PR DESCRIPTION
For some old builds, we may not define cache partition size. Change the
exception into a warning to make the script backward compatible.

Change-Id: Ie94c7fbb1a9f3a7db3f16e8d845e493a534aac5b